### PR TITLE
Rename _run_git function to run_git (#25)

### DIFF
--- a/greening/_commands/deploy.py
+++ b/greening/_commands/deploy.py
@@ -6,7 +6,7 @@ from cookiecutter.main import cookiecutter
 from importlib_resources import files
 
 from greening.greening_config import GreeningConfig
-from greening._helpers import _run_git
+from greening._helpers import run_git
 
 def deploy_site():
     """
@@ -62,24 +62,24 @@ def _deploy_rendered_site(rendered_path: Path, config: GreeningConfig):
     should_push = config.data.get("push", False)
 
     try:
-        _run_git("git rev-parse --verify gh-pages", cwd=repo_root)
-        _run_git("git checkout gh-pages", cwd=repo_root)
+        run_git("git rev-parse --verify gh-pages", cwd=repo_root)
+        run_git("git checkout gh-pages", cwd=repo_root)
     except subprocess.CalledProcessError:
-        _run_git("git checkout --orphan gh-pages", cwd=repo_root)
+        run_git("git checkout --orphan gh-pages", cwd=repo_root)
 
-    _run_git("git rm -rf .", cwd=repo_root)
+    run_git("git rm -rf .", cwd=repo_root)
 
     for item in rendered_path.iterdir():
         shutil.move(str(item), str(repo_root / item.name))
 
-    _run_git("git add .gitignore", cwd=repo_root)
-    _run_git("git add .", cwd=repo_root)
-    _run_git("git commit -m 'Deploy Jekyll site'", cwd=repo_root)
+    run_git("git add .gitignore", cwd=repo_root)
+    run_git("git add .", cwd=repo_root)
+    run_git("git commit -m 'Deploy Jekyll site'", cwd=repo_root)
 
     if should_push:
         print("🚀 Pushing gh-pages to origin...")
-        _run_git("git push -f origin gh-pages", cwd=repo_root)
+        run_git("git push -f origin gh-pages", cwd=repo_root)
     else:
         print("⚠️  Push skipped (set push: true in greening.yaml to enable)")
 
-    _run_git("git checkout main", cwd=repo_root)
+    run_git("git checkout main", cwd=repo_root)

--- a/greening/_commands/new.py
+++ b/greening/_commands/new.py
@@ -9,7 +9,7 @@ import tempfile
 from typing import Union
 
 from greening.greening_config import GreeningConfig
-from greening._helpers import _run_git
+from greening._helpers import run_git
 
 def new():
     """
@@ -98,10 +98,10 @@ def _maybe_initialize_git_repo(config: GreeningConfig):
         return
 
     print("🔧 Initializing git repo...")
-    _run_git("git init", cwd=project_dir)
-    _run_git("git add .", cwd=project_dir)
-    _run_git("git commit -m 'Initial commit'", cwd=project_dir)
-    _run_git("git branch -M main", cwd=project_dir)
+    run_git("git init", cwd=project_dir)
+    run_git("git add .", cwd=project_dir)
+    run_git("git commit -m 'Initial commit'", cwd=project_dir)
+    run_git("git branch -M main", cwd=project_dir)
 
     git_remote = config.data.get("git_remote")
     create_repo = config.data.get("create_github_repo", False)
@@ -114,11 +114,11 @@ def _maybe_initialize_git_repo(config: GreeningConfig):
 
     if git_remote:
         print(f"🔗 Adding git remote: {git_remote}")
-        _run_git(f"git remote add origin {git_remote}", cwd=project_dir)
+        run_git(f"git remote add origin {git_remote}", cwd=project_dir)
 
         if push_enabled:
             print("🚀 Pushing to GitHub...")
-            _run_git("git push -u origin main", cwd=project_dir)
+            run_git("git push -u origin main", cwd=project_dir)
         else:
             print("⚠️  Push skipped (set push: true in greening.yaml to enable)")
 

--- a/greening/_helpers.py
+++ b/greening/_helpers.py
@@ -4,7 +4,7 @@ import subprocess
 from typing import Union
 import os
 
-def _run_git(command: str, cwd: Path):
+def run_git(command: str, cwd: Path):
     """
     Runs a full git command string using shlex.split() for safety.
     e.g. 'git commit -m "message with spaces"'


### PR DESCRIPTION
This Pull Request resolves issue #25 by renaming the `_run_git` function to `run_git` and updating all references in the `deploy` and `new` modules. This change improves consistency and aligns with the updated structure of the `_helpers` module.