### PR TITLE
Add centralized GreeningConfig for cookiecutter.json

### DIFF
--- a/greening/greening_config.py
+++ b/greening/greening_config.py
@@ -64,5 +64,6 @@ venv:
             "author_name": self.data.get("author_name"),
             "email": self.data.get("email"),
             "venv_create": str(self.data.get("venv", {}).get("create", False)).lower(),
-            "python": self.data.get("venv", {}).get("python", "python3")
+            "python": self.data.get("venv", {}).get("python", "python3"),
+            "google_analytics": self.data.get("google_analytics", {}).get("G-XXXXXXXXXX")
         }

--- a/greening/greening_config.py
+++ b/greening/greening_config.py
@@ -52,9 +52,6 @@ venv:
         self.path.write_text(self.DEFAULT_YAML)
         print(f"✅ Created default greening.yaml at {self.path}")
 
-    def to_cookiecutter_context(self):
-        return self.data
-
     @property
     def docs_enabled(self):
         return self.data.get("docs", {}).get("init", False)

--- a/greening/templates/python-package-template/cookiecutter.json
+++ b/greening/templates/python-package-template/cookiecutter.json
@@ -1,9 +1,0 @@
-{
-  "project_name": "My Greening Project",
-  "project_slug": "my_greening_project",
-  "author_name": "Your Name",
-  "email": "your@email.com",
-  "github_username": "your-github-username",
-  "venv_create": "false",
-  "python": "python3"
-}

--- a/greening/templates/site-template/cookiecutter.json
+++ b/greening/templates/site-template/cookiecutter.json
@@ -1,8 +1,0 @@
-{
-  "project_name": "My Cool Project",
-  "project_slug": "my_cool_project",
-  "author_name": "Your Name",
-  "email": "you@example.com",
-  "github_username": "your-github",
-  "google_analytics": "your-google-analytics"
-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "greening"
-version = "0.4.13"
+version = "0.4.14"
 description = "A creative dev automation engine for launching, documenting, and publishing projects"
 authors = [
     { name = "Christopher Greening", email = "chris@christophergreening.com" }


### PR DESCRIPTION
Add `GreeningConfig` as the only cookiecutter configuration to prevent having to define `cookiecutter.json` everywhere